### PR TITLE
Move semantics

### DIFF
--- a/library/tinysplinecpp.cpp
+++ b/library/tinysplinecpp.cpp
@@ -32,6 +32,15 @@ ts::DeBoorNet& ts::DeBoorNet::operator=(const ts::DeBoorNet& other)
     return *this;
 }
 
+ts::DeBoorNet& ts::DeBoorNet::operator=(ts::DeBoorNet&& other)
+{
+    if (&other != this) {
+        ts_deboornet_free(&deBoorNet);
+        swap(other);
+    }
+    return *this;
+}
+
 void ts::DeBoorNet::swap(ts::DeBoorNet& other)
 {
     if (&other != this) {
@@ -147,6 +156,15 @@ ts::BSpline& ts::BSpline::operator=(const ts::BSpline& other)
     const tsError err = ts_bspline_copy(&other.bspline, &bspline);
     if (err < 0)
         throw std::runtime_error(ts_enum_str(err));
+    return *this;
+}
+
+ts::BSpline& ts::BSpline::operator=(ts::BSpline&& other)
+{
+    if (&other != this) {
+        ts_bspline_free(&bspline);
+        swap(other);
+    }
     return *this;
 }
 

--- a/library/tinysplinecpp.cpp
+++ b/library/tinysplinecpp.cpp
@@ -45,7 +45,6 @@ void ts::DeBoorNet::swap(ts::DeBoorNet& other)
 {
     if (&other != this) {
         std::swap(deBoorNet.u, other.deBoorNet.u);
-        std::swap(deBoorNet.u, other.deBoorNet.u);
         std::swap(deBoorNet.k, other.deBoorNet.k);
         std::swap(deBoorNet.s, other.deBoorNet.s);
         std::swap(deBoorNet.h, other.deBoorNet.h);

--- a/library/tinysplinecpp.cpp
+++ b/library/tinysplinecpp.cpp
@@ -26,6 +26,21 @@ ts::DeBoorNet& ts::DeBoorNet::operator=(const ts::DeBoorNet& other)
     return *this;
 }
 
+void ts::DeBoorNet::swap(ts::DeBoorNet& other)
+{
+    if (&other != this) {
+        std::swap(deBoorNet.u, other.deBoorNet.u);
+        std::swap(deBoorNet.u, other.deBoorNet.u);
+        std::swap(deBoorNet.k, other.deBoorNet.k);
+        std::swap(deBoorNet.s, other.deBoorNet.s);
+        std::swap(deBoorNet.h, other.deBoorNet.h);
+        std::swap(deBoorNet.dim, other.deBoorNet.dim);
+        std::swap(deBoorNet.n_points, other.deBoorNet.n_points);
+        std::swap(deBoorNet.points, other.deBoorNet.points);
+        std::swap(deBoorNet.result, other.deBoorNet.result);
+    }
+}
+
 float ts::DeBoorNet::u() const
 {
     return deBoorNet.u;
@@ -121,6 +136,19 @@ ts::BSpline& ts::BSpline::operator=(const ts::BSpline& other)
     if (err < 0)
         throw std::runtime_error(ts_enum_str(err));
     return *this;
+}
+
+void ts::BSpline::swap(ts::BSpline &other)
+{
+    if (&other != this) {
+        std::swap(bspline.deg, other.bspline.deg);
+        std::swap(bspline.order, other.bspline.order);
+        std::swap(bspline.dim, other.bspline.dim);
+        std::swap(bspline.n_ctrlp, other.bspline.n_ctrlp);
+        std::swap(bspline.n_knots, other.bspline.n_knots);
+        std::swap(bspline.ctrlp, other.bspline.ctrlp);
+        std::swap(bspline.knots, other.bspline.knots);
+    }
 }
 
 ts::DeBoorNet ts::BSpline::operator()(const float u) const

--- a/library/tinysplinecpp.cpp
+++ b/library/tinysplinecpp.cpp
@@ -13,6 +13,12 @@ ts::DeBoorNet::DeBoorNet(const ts::DeBoorNet& other)
         throw std::runtime_error(ts_enum_str(err));
 }
 
+ts::DeBoorNet::DeBoorNet(DeBoorNet&& other)
+{
+    ts_deboornet_default(&deBoorNet);
+    swap(other);
+}
+
 ts::DeBoorNet::~DeBoorNet()
 {
     ts_deboornet_free(&deBoorNet);
@@ -103,6 +109,12 @@ ts::BSpline::BSpline(const ts::BSpline& other)
     const tsError err = ts_bspline_copy(&other.bspline, &bspline);
     if (err < 0)
         throw std::runtime_error(ts_enum_str(err));
+}
+
+ts::BSpline::BSpline(ts::BSpline&& other)
+{
+    ts_bspline_default(&bspline);
+    swap(other);
 }
 
 ts::BSpline::BSpline(const size_t deg, const size_t dim, const size_t nCtrlp,

--- a/library/tinysplinecpp.h
+++ b/library/tinysplinecpp.h
@@ -14,6 +14,9 @@ public:
 
     DeBoorNet& operator=(const DeBoorNet& other);
 
+    void swap(DeBoorNet& other);
+    friend void swap(DeBoorNet &left, DeBoorNet &right) { left.swap(right); }
+
     float u() const;
     size_t k() const;
     size_t s() const;
@@ -38,6 +41,10 @@ public:
     ~BSpline();
 
     BSpline& operator=(const BSpline& other);
+
+    void swap(BSpline& other);
+    friend void swap(BSpline &left, BSpline &right) { left.swap(right); }
+
     DeBoorNet operator()(const float u) const;
 
     size_t deg() const;

--- a/library/tinysplinecpp.h
+++ b/library/tinysplinecpp.h
@@ -14,6 +14,7 @@ public:
     ~DeBoorNet();
 
     DeBoorNet& operator=(const DeBoorNet& other);
+    DeBoorNet& operator=(DeBoorNet&& other);
 
     void swap(DeBoorNet& other);
     friend void swap(DeBoorNet &left, DeBoorNet &right) { left.swap(right); }
@@ -43,6 +44,7 @@ public:
     ~BSpline();
 
     BSpline& operator=(const BSpline& other);
+    BSpline& operator=(BSpline&& other);
 
     void swap(BSpline& other);
     friend void swap(BSpline &left, BSpline &right) { left.swap(right); }

--- a/library/tinysplinecpp.h
+++ b/library/tinysplinecpp.h
@@ -10,6 +10,7 @@ class DeBoorNet {
 public:
     DeBoorNet();
     DeBoorNet(const DeBoorNet& other);
+    DeBoorNet(DeBoorNet&& other);
     ~DeBoorNet();
 
     DeBoorNet& operator=(const DeBoorNet& other);
@@ -35,6 +36,7 @@ class BSpline {
 public:
     BSpline();
     BSpline(const BSpline& other);
+    BSpline(BSpline&& other);
     BSpline(const size_t deg, const size_t dim, const size_t nCtrlp,
             const tsBSplineType type);
     BSpline(const std::vector<float> points, const size_t dim);


### PR DESCRIPTION
Hi,
I've added _swap_, _move constructors_ and _move assignment operators_ to the C++11 wrapper.
These are faster than the copy operator since point and knot arrays are not allocated and copied, but the pointers are just swapped.
It might be useful, e.g., when pushing splines back into a STL container.