### PR TITLE
made move semantics optional for not C+11 compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,21 @@
 cmake_minimum_required(VERSION 2.8)
 project(tinyspline)
 
+# set options
+option( TS_CPP_WITH_MOVE_SEMANTICS "Build C++ wrapper with move semantics (C++11 compiler required)" OFF )
+if( TS_CPP_WITH_MOVE_SEMANTICS )
+    add_definitions(    -DWITH_MOVE_SEMANTICS )
+endif()
+option( TS_BINDING_PYTHON "Build Python binding" ON )
+option( TS_BINDING_RUBY "Build Ruby binding" ON )
+option( TS_BINDING_JAVA "Build Java binding" ON )
+option( TS_BINDING_CSHARP "Build CSHARP binding" ON )
+option( TS_BUILD_EXAMPLES "Build the examples" ON )
+
+# Turn on using solution folders
+set_property( GLOBAL PROPERTY USE_FOLDERS ON)
+
 add_subdirectory(library)
-add_subdirectory(example)
+if( TS_BUILD_EXAMPLES )
+  add_subdirectory(example)
+endif()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -23,19 +23,25 @@ endif()
 if(GLUT_FOUND AND OPENGL_FOUND)
   add_executable(bspline bspline.c)
   target_link_libraries(bspline LINK_PUBLIC tinyspline_static ${OPENGL_LIBRARIES} ${GLUT_LIBRARIES})
+  set_target_properties(bspline PROPERTIES FOLDER "examples" DEBUG_POSTFIX d)
   
   add_executable(nurbs nurbs.c)
   target_link_libraries(nurbs LINK_PUBLIC tinyspline_static ${OPENGL_LIBRARIES} ${GLUT_LIBRARIES})
+  set_target_properties(nurbs PROPERTIES FOLDER "examples" DEBUG_POSTFIX d)
   
   add_executable(split split.c)
   target_link_libraries(split LINK_PUBLIC tinyspline_static ${OPENGL_LIBRARIES} ${GLUT_LIBRARIES})
+  set_target_properties(split PROPERTIES FOLDER "examples" DEBUG_POSTFIX d)
 
   add_executable(beziers beziers.c)
   target_link_libraries(beziers LINK_PUBLIC tinyspline_static ${OPENGL_LIBRARIES} ${GLUT_LIBRARIES})
+  set_target_properties(beziers PROPERTIES FOLDER "examples" DEBUG_POSTFIX d)
 
   add_executable(interpolation interpolation.c)
   target_link_libraries(interpolation LINK_PUBLIC tinyspline_static ${OPENGL_LIBRARIES} ${GLUT_LIBRARIES})
+  set_target_properties(interpolation PROPERTIES FOLDER "examples" DEBUG_POSTFIX d)
 
   add_executable(derivative derivative.c)
   target_link_libraries(derivative LINK_PUBLIC tinyspline_static ${OPENGL_LIBRARIES} ${GLUT_LIBRARIES})
+  set_target_properties(derivative PROPERTIES FOLDER "examples" DEBUG_POSTFIX d)
 endif()

--- a/example/beziers.c
+++ b/example/beziers.c
@@ -79,11 +79,11 @@ void display(void)
     gluBeginCurve(theNurb);
         gluNurbsCurve(
             theNurb,
-            draw.n_knots,
+            (GLint)draw.n_knots,
             draw.knots,
-            draw.dim,
+            (GLint)draw.dim,
             draw.ctrlp,
-            draw.order,
+            (GLint)draw.order,
             GL_MAP1_VERTEX_3
         );
     gluEndCurve(theNurb);

--- a/example/bspline.c
+++ b/example/bspline.c
@@ -75,11 +75,11 @@ void display(void)
     gluBeginCurve(theNurb);
         gluNurbsCurve(
             theNurb, 
-            spline.n_knots, 
+            (GLint)spline.n_knots,
             spline.knots, 
-            spline.dim, 
+            (GLint)spline.dim,
             spline.ctrlp, 
-            spline.order, 
+            (GLint)spline.order,
             GL_MAP1_VERTEX_3
         );
     gluEndCurve(theNurb);

--- a/example/derivative.c
+++ b/example/derivative.c
@@ -79,11 +79,11 @@ void display(void)
     gluBeginCurve(theNurb);
     gluNurbsCurve(
                   theNurb,
-                  spline.n_knots,
+                  (GLint)spline.n_knots,
                   spline.knots,
-                  spline.dim,
+                  (GLint)spline.dim,
                   spline.ctrlp,
-                  spline.order,
+                  (GLint)spline.order,
                   GL_MAP1_VERTEX_3
                   );
     gluEndCurve(theNurb);
@@ -117,7 +117,7 @@ void display(void)
     ts_deboornet_free(&net2);
     ts_deboornet_free(&net3);
 
-    u += 0.001;
+    u += 0.001f;
     if (u > 1.f) {
         u = 0.f;
     }

--- a/example/interpolation.c
+++ b/example/interpolation.c
@@ -63,11 +63,11 @@ void display(void)
     gluBeginCurve(theNurb);
         gluNurbsCurve(
             theNurb, 
-            spline.n_knots, 
+            (GLint)spline.n_knots,
             spline.knots, 
-            spline.dim, 
+            (GLint)spline.dim,
             spline.ctrlp, 
-            spline.order, 
+            (GLint)spline.order,
             GL_MAP1_VERTEX_3
         );
     gluEndCurve(theNurb);

--- a/example/nurbs.c
+++ b/example/nurbs.c
@@ -106,11 +106,11 @@ void display(void)
     gluBeginCurve(theNurb);
         gluNurbsCurve(
             theNurb, 
-            spline.n_knots, 
+            (GLint)spline.n_knots,
             spline.knots, 
-            spline.dim, 
+            (GLint)spline.dim,
             spline.ctrlp, 
-            spline.order, 
+            (GLint)spline.order,
             GL_MAP1_VERTEX_4
         );
     gluEndCurve(theNurb);
@@ -134,7 +134,7 @@ void display(void)
     glEnd();
     ts_deboornet_free(&net);
     
-    u += 0.001;
+    u += 0.001f;
     if (u > 1.f) {
         u = 0.f;
     }

--- a/example/split.c
+++ b/example/split.c
@@ -79,11 +79,11 @@ void display(void)
     gluBeginCurve(theNurb);
         gluNurbsCurve(
             theNurb, 
-            split.n_knots, 
+            (GLint)split.n_knots,
             split.knots, 
-            split.dim, 
+            (GLint)split.dim,
             split.ctrlp, 
-            split.order, 
+            (GLint)split.order,
             GL_MAP1_VERTEX_3
         );
     gluEndCurve(theNurb);
@@ -108,7 +108,7 @@ void display(void)
     glEnd();
     ts_deboornet_free(&net);
     
-    u += 0.001;
+    u += 0.001f;
     if (u > 1.f) {
         u = 0.f;
     }

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -54,9 +54,10 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(TS_CPP_AVAILABLE TRUE)
   endif()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Wall /WX /wd4820 /wd4711")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Wall /WX /wd4820 /wd4711 /wd4255")
 
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 18 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 18)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 18 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 18
+     OR NOT TS_CPP_WITH_MOVE_SEMANTICS )
     # using WX causes to many errors in generated source code, thus, use W4 instead
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Wall /W4 /wd4702")
     set(TS_CPP_AVAILABLE TRUE)
@@ -122,118 +123,132 @@ if(TS_CPP_AVAILABLE AND SWIG_FOUND AND TARGET_SUPPORTS_SHARED_LIBS)
   include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
   # define the output dirs
-  set(TS_GENERATED_PYTHON_DIR ${CMAKE_CURRENT_BINARY_DIR}/python)
-  set(TS_GENERATED_JAVA_DIR ${CMAKE_CURRENT_BINARY_DIR}/so/tinyspline)
-  set(TS_GENERATED_CSHARP_DIR ${CMAKE_CURRENT_BINARY_DIR}/csharp)
-  set(TS_GENERATED_RUBY_DIR ${CMAKE_CURRENT_BINARY_DIR}/ruby)
+  set(TS_GENERATED_PYTHON_DIR ${CMAKE_CURRENT_BINARY_DIR}/python CACHE STRING "Output folder for Python binding")
+  set(TS_GENERATED_JAVA_DIR ${CMAKE_CURRENT_BINARY_DIR}/so/tinyspline CACHE STRING "Output folder for Java binding")
+  set(TS_GENERATED_CSHARP_DIR ${CMAKE_CURRENT_BINARY_DIR}/csharp CACHE STRING "Output folder for CSHARP binding")
+  set(TS_GENERATED_RUBY_DIR ${CMAKE_CURRENT_BINARY_DIR}/ruby CACHE STRING "Output folder for Ruby binding")
 
   # python
-  if(DEFINED ENV{PYTHON_LIBRARY} AND DEFINED ENV{PYTHON_INCLUDE_DIR})
-    message(STATUS "Using environment variables PYTHON_LIBRARY and PYTHON_INCLUDE_DIR")
-    set(PYTHON_LIBRARY $ENV{PYTHON_LIBRARY})
-    set(PYTHON_INCLUDE_DIR $ENV{PYTHON_INCLUDE_DIR})
-  endif()
-  find_package(PythonLibs)
-  if (PYTHONLIBS_FOUND)
-    include_directories(${PYTHON_INCLUDE_DIRS})
-    set_source_files_properties(tinysplinepython.i PROPERTIES CPLUSPLUS ON)
-    if (${PYTHONLIBS_VERSION_STRING} MATCHES "^3.")
-      message(STATUS "Using Python 3 mode.")
-      set(CMAKE_SWIG_FLAGS -py3 -O)
-    else()
-      message(STATUS "Using Python 2 mode.")
-      set(CMAKE_SWIG_FLAGS -O)
+  if( TS_BINDING_PYTHON )
+    if(DEFINED ENV{PYTHON_LIBRARY} AND DEFINED ENV{PYTHON_INCLUDE_DIR})
+      message(STATUS "Using environment variables PYTHON_LIBRARY and PYTHON_INCLUDE_DIR")
+      set(PYTHON_LIBRARY $ENV{PYTHON_LIBRARY})
+      set(PYTHON_INCLUDE_DIR $ENV{PYTHON_INCLUDE_DIR})
     endif()
-    set(CMAKE_SWIG_OUTDIR ${TS_GENERATED_PYTHON_DIR})
-    swig_add_module(tinysplinepython python tinysplinepython.i tinyspline.c tinysplinecpp.cpp)
-    swig_link_libraries(tinysplinepython ${PYTHON_LIBRARIES})
-    # for some reason the generated make target for python is _tinysplinepython
-    add_custom_command(TARGET _tinysplinepython POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy ${TS_GENERATED_PYTHON_DIR}/tinysplinepython.py
-      ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.py
-    )
+    find_package(PythonLibs)
+    if (PYTHONLIBS_FOUND)
+      include_directories(${PYTHON_INCLUDE_DIRS})
+      set_source_files_properties(tinysplinepython.i PROPERTIES CPLUSPLUS ON)
+      if (${PYTHONLIBS_VERSION_STRING} MATCHES "^3.")
+        message(STATUS "Using Python 3 mode.")
+        set(CMAKE_SWIG_FLAGS -py3 -O)
+      else()
+        message(STATUS "Using Python 2 mode.")
+        set(CMAKE_SWIG_FLAGS -O)
+      endif()
+      set(CMAKE_SWIG_OUTDIR ${TS_GENERATED_PYTHON_DIR})
+      swig_add_module(tinysplinepython python tinysplinepython.i tinyspline.c tinysplinecpp.cpp)
+      swig_link_libraries(tinysplinepython ${PYTHON_LIBRARIES})
+      # for some reason the generated make target for python is _tinysplinepython
+      add_custom_command(TARGET _tinysplinepython POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy ${TS_GENERATED_PYTHON_DIR}/tinysplinepython.py
+        ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.py
+      )
+      set_target_properties(tinysplinepython PROPERTIES FOLDER "bindings")
+    endif()
   endif()
 
   # java
-  find_package(JNI)
-  if(JNI_FOUND)
-    include_directories(${JAVA_INCLUDE_PATH} ${JAVA_INCLUDE_PATH2})
-    set_source_files_properties(tinysplinejava.i PROPERTIES CPLUSPLUS ON)
-    set(CMAKE_SWIG_FLAGS -package "so.tinyspline" -O)
-    set(CMAKE_SWIG_OUTDIR ${TS_GENERATED_JAVA_DIR})
-    swig_add_module(tinysplinejava java tinysplinejava.i tinyspline.c tinysplinecpp.cpp)
-    swig_link_libraries(tinysplinejava ${JAVA_LIBRARIES})
-    
-    find_package(Java COMPONENTS Development)
-    if(Java_Development_FOUND)
-      include(UseJava)
-      add_jar(tinysplinejar 
-        ${TS_GENERATED_JAVA_DIR}/SWIGTYPE_p_float.java
-        ${TS_GENERATED_JAVA_DIR}/SWIGTYPE_p_size_t.java
-        ${TS_GENERATED_JAVA_DIR}/SWIGTYPE_p_tsBSpline.java
-        ${TS_GENERATED_JAVA_DIR}/SWIGTYPE_p_tsDeBoorNet.java
-        ${TS_GENERATED_JAVA_DIR}/SWIGTYPE_tsError.java
-        ${TS_GENERATED_JAVA_DIR}/tinysplinejava.java
-        ${TS_GENERATED_JAVA_DIR}/tinysplinejavaJNI.java
-        ${TS_GENERATED_JAVA_DIR}/BSpline.java
-        ${TS_GENERATED_JAVA_DIR}/tsBSplineType.java
-        ${TS_GENERATED_JAVA_DIR}/DeBoorNet.java
-        ${TS_GENERATED_JAVA_DIR}/FloatVector.java
-        OUTPUT_NAME tinyspline
-      )
-      add_dependencies(tinysplinejar tinysplinejava)
+  if( TS_BINDING_JAVA )
+    find_package(JNI)
+    if(JNI_FOUND)
+      include_directories(${JAVA_INCLUDE_PATH} ${JAVA_INCLUDE_PATH2})
+      set_source_files_properties(tinysplinejava.i PROPERTIES CPLUSPLUS ON)
+      set(CMAKE_SWIG_FLAGS -package "so.tinyspline" -O)
+      set(CMAKE_SWIG_OUTDIR ${TS_GENERATED_JAVA_DIR})
+      swig_add_module(tinysplinejava java tinysplinejava.i tinyspline.c tinysplinecpp.cpp)
+      swig_link_libraries(tinysplinejava ${JAVA_LIBRARIES})
+      
+      find_package(Java COMPONENTS Development)
+      if(Java_Development_FOUND)
+        include(UseJava)
+        add_jar(tinysplinejar 
+          ${TS_GENERATED_JAVA_DIR}/SWIGTYPE_p_float.java
+          ${TS_GENERATED_JAVA_DIR}/SWIGTYPE_p_size_t.java
+          ${TS_GENERATED_JAVA_DIR}/SWIGTYPE_p_tsBSpline.java
+          ${TS_GENERATED_JAVA_DIR}/SWIGTYPE_p_tsDeBoorNet.java
+          ${TS_GENERATED_JAVA_DIR}/SWIGTYPE_tsError.java
+          ${TS_GENERATED_JAVA_DIR}/tinysplinejava.java
+          ${TS_GENERATED_JAVA_DIR}/tinysplinejavaJNI.java
+          ${TS_GENERATED_JAVA_DIR}/BSpline.java
+          ${TS_GENERATED_JAVA_DIR}/tsBSplineType.java
+          ${TS_GENERATED_JAVA_DIR}/DeBoorNet.java
+          ${TS_GENERATED_JAVA_DIR}/FloatVector.java
+          OUTPUT_NAME tinyspline
+        )
+        add_dependencies(tinysplinejar tinysplinejava)
+        set_target_properties(tinysplinejar PROPERTIES FOLDER "bindings")
+      endif()
+      
+      set_target_properties(tinysplinejava PROPERTIES FOLDER "bindings")
     endif()
   endif()
 
   # csharp
-  set_source_files_properties(tinysplinecsharp.i PROPERTIES CPLUSPLUS ON)
-  set(CMAKE_SWIG_FLAGS -namespace ts -O)
-  set(CMAKE_SWIG_OUTDIR ${TS_GENERATED_CSHARP_DIR})
-  swig_add_module(tinysplinecsharp csharp tinysplinecsharp.i tinyspline.c tinysplinecpp.cpp)
-  find_program(CSHARP_COMPILER
-    NAMES csc mcs dmcs gmcs
-    PATHS "C:/Windows/Microsoft.NET/Framework/v3.5/bin"
-  )
-  if(NOT CSHARP_COMPILER)
-    message(STATUS "Could NOT find any suitable C# compiler.")
-  else()
-    message(STATUS "Using ${CSHARP_COMPILER} to compile C# sources.")
-    # append 'cs' to assembly name to ensure it doesn't clash
-    # with the c library.
-    add_custom_command(TARGET tinysplinecsharp POST_BUILD
-      COMMAND ${CSHARP_COMPILER} /t:library /sdk:2 /recurse:"${TS_GENERATED_CSHARP_DIR}/*.cs" /out:tinysplinecs.dll
+  if( TS_BINDING_CSHARP )
+    set_source_files_properties(tinysplinecsharp.i PROPERTIES CPLUSPLUS ON)
+    set(CMAKE_SWIG_FLAGS -namespace ts -O)
+    set(CMAKE_SWIG_OUTDIR ${TS_GENERATED_CSHARP_DIR})
+    swig_add_module(tinysplinecsharp csharp tinysplinecsharp.i tinyspline.c tinysplinecpp.cpp)
+    find_program(CSHARP_COMPILER
+      NAMES csc mcs dmcs gmcs
+      PATHS "C:/Windows/Microsoft.NET/Framework/v3.5/bin"
     )
+    if(NOT CSHARP_COMPILER)
+      message(STATUS "Could NOT find any suitable C# compiler.")
+    else()
+      message(STATUS "Using ${CSHARP_COMPILER} to compile C# sources.")
+      # append 'cs' to assembly name to ensure it doesn't clash
+      # with the c library.
+      add_custom_command(TARGET tinysplinecsharp POST_BUILD
+        COMMAND ${CSHARP_COMPILER} /t:library /sdk:2 /recurse:"${TS_GENERATED_CSHARP_DIR}/*.cs" /out:tinysplinecs.dll
+      )
+    endif()
+    set_target_properties(tinysplinecsharp PROPERTIES FOLDER "bindings")
   endif()
 
   # ruby
-  find_package(Ruby)
-  if(RUBY_FOUND)
-    include_directories(${RUBY_INCLUDE_DIRS})
-    set_source_files_properties(tinysplineruby.i PROPERTIES CPLUSPLUS ON)
-    set(CMAKE_SWIG_FLAGS -O)
-    set(CMAKE_SWIG_OUTDIR ${TS_GENERATED_RUBY_DIR})
-    swig_add_module(tinysplineruby ruby tinysplineruby.i tinyspline.c tinysplinecpp.cpp)
-    swig_link_libraries(tinysplineruby ${RUBY_LIBRARY})
-    # for additional information please see the 'tinysplineruby.i' SWIG file.
-    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb  "require 'tinysplineruby'\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "module Tinyspline\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "  class BSpline < Tinysplineruby::BSpline\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "    def ctrlp=(ctrlp)\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "      setCtrlp(ctrlp)\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "    end\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "    def knots=(knots)\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "      setKnots(knots)\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "    end\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "  end\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "  class DeBoorNet < Tinysplineruby::DeBoorNet\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "  end\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "  class Utils < Tinysplineruby::Utils\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "  end\n")
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "end")
+  if( TS_BINDING_RUBY )
+    find_package(Ruby)
+    if(RUBY_FOUND)
+      include_directories(${RUBY_INCLUDE_DIRS})
+      set_source_files_properties(tinysplineruby.i PROPERTIES CPLUSPLUS ON)
+      set(CMAKE_SWIG_FLAGS -O)
+      set(CMAKE_SWIG_OUTDIR ${TS_GENERATED_RUBY_DIR})
+      swig_add_module(tinysplineruby ruby tinysplineruby.i tinyspline.c tinysplinecpp.cpp)
+      swig_link_libraries(tinysplineruby ${RUBY_LIBRARY})
+      # for additional information please see the 'tinysplineruby.i' SWIG file.
+      file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb  "require 'tinysplineruby'\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "module Tinyspline\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "  class BSpline < Tinysplineruby::BSpline\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "    def ctrlp=(ctrlp)\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "      setCtrlp(ctrlp)\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "    end\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "    def knots=(knots)\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "      setKnots(knots)\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "    end\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "  end\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "  class DeBoorNet < Tinysplineruby::DeBoorNet\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "  end\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "  class Utils < Tinysplineruby::Utils\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "  end\n")
+      file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.rb "end")
+      set_target_properties(tinysplineruby PROPERTIES FOLDER "bindings")
+    endif()
   endif()
 
   # add additional clean targets

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -139,22 +139,22 @@ if(TS_CPP_AVAILABLE AND SWIG_FOUND AND TARGET_SUPPORTS_SHARED_LIBS)
     if (PYTHONLIBS_FOUND)
       include_directories(${PYTHON_INCLUDE_DIRS})
       set_source_files_properties(tinysplinepython.i PROPERTIES CPLUSPLUS ON)
+      set_source_files_properties(tinysplinepython.i PROPERTIES SWIG_MODULE_NAME tinyspline)
       if (${PYTHONLIBS_VERSION_STRING} MATCHES "^3.")
         message(STATUS "Using Python 3 mode.")
-        set(CMAKE_SWIG_FLAGS -py3 -O)
+        set(CMAKE_SWIG_FLAGS -py3 -O -module tinyspline)
       else()
         message(STATUS "Using Python 2 mode.")
-        set(CMAKE_SWIG_FLAGS -O)
+        set(CMAKE_SWIG_FLAGS -O -module tinyspline)
       endif()
       set(CMAKE_SWIG_OUTDIR ${TS_GENERATED_PYTHON_DIR})
-      swig_add_module(tinysplinepython python tinysplinepython.i tinyspline.c tinysplinecpp.cpp)
-      swig_link_libraries(tinysplinepython ${PYTHON_LIBRARIES})
-      # for some reason the generated make target for python is _tinysplinepython
-      add_custom_command(TARGET _tinysplinepython POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy ${TS_GENERATED_PYTHON_DIR}/tinysplinepython.py
+      swig_add_module(tinyspline python tinysplinepython.i tinyspline.c tinysplinecpp.cpp)      
+      swig_link_libraries(tinyspline ${PYTHON_LIBRARIES})
+      add_custom_command(TARGET _tinyspline POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy ${TS_GENERATED_PYTHON_DIR}/tinyspline.py
         ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.py
       )
-      set_target_properties(_tinysplinepython PROPERTIES FOLDER "bindings")
+      set_target_properties(_tinyspline PROPERTIES FOLDER "bindings")
     endif()
   endif()
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -154,7 +154,7 @@ if(TS_CPP_AVAILABLE AND SWIG_FOUND AND TARGET_SUPPORTS_SHARED_LIBS)
         COMMAND ${CMAKE_COMMAND} -E copy ${TS_GENERATED_PYTHON_DIR}/tinysplinepython.py
         ${CMAKE_CURRENT_BINARY_DIR}/tinyspline.py
       )
-      set_target_properties(tinysplinepython PROPERTIES FOLDER "bindings")
+      set_target_properties(_tinysplinepython PROPERTIES FOLDER "bindings")
     endif()
   endif()
 

--- a/library/tinysplinecpp.cpp
+++ b/library/tinysplinecpp.cpp
@@ -13,11 +13,13 @@ ts::DeBoorNet::DeBoorNet(const ts::DeBoorNet& other)
         throw std::runtime_error(ts_enum_str(err));
 }
 
+#ifdef WITH_MOVE_SEMANTICS
 ts::DeBoorNet::DeBoorNet(DeBoorNet&& other)
 {
     ts_deboornet_default(&deBoorNet);
     swap(other);
 }
+#endif
 
 ts::DeBoorNet::~DeBoorNet()
 {
@@ -34,6 +36,7 @@ ts::DeBoorNet& ts::DeBoorNet::operator=(const ts::DeBoorNet& other)
     return *this;
 }
 
+#ifdef WITH_MOVE_SEMANTICS
 ts::DeBoorNet& ts::DeBoorNet::operator=(ts::DeBoorNet&& other)
 {
     if (&other != this) {
@@ -56,6 +59,7 @@ void ts::DeBoorNet::swap(ts::DeBoorNet& other)
         std::swap(deBoorNet.result, other.deBoorNet.result);
     }
 }
+#endif
 
 float ts::DeBoorNet::u() const
 {
@@ -121,11 +125,13 @@ ts::BSpline::BSpline(const ts::BSpline& other)
         throw std::runtime_error(ts_enum_str(err));
 }
 
+#ifdef WITH_MOVE_SEMANTICS
 ts::BSpline::BSpline(ts::BSpline&& other)
 {
     ts_bspline_default(&bspline);
     swap(other);
 }
+#endif
 
 ts::BSpline::BSpline(const size_t deg, const size_t dim, const size_t nCtrlp,
                      const tsBSplineType type)
@@ -142,7 +148,7 @@ ts::BSpline::BSpline(const std::vector<float> points, const size_t dim)
     if (points.size() % dim != 0)
         throw std::runtime_error("#points % dim == 0 failed");
     const tsError err = ts_bspline_interpolate(
-            points.data(), points.size()/dim, dim, &bspline);
+            &points.front(), points.size()/dim, dim, &bspline);
     if (err < 0)
         throw std::runtime_error(ts_enum_str(err));
 }
@@ -162,6 +168,7 @@ ts::BSpline& ts::BSpline::operator=(const ts::BSpline& other)
     return *this;
 }
 
+#ifdef WITH_MOVE_SEMANTICS
 ts::BSpline& ts::BSpline::operator=(ts::BSpline&& other)
 {
     if (&other != this) {
@@ -170,12 +177,14 @@ ts::BSpline& ts::BSpline::operator=(ts::BSpline&& other)
     }
     return *this;
 }
+#endif
 
 ts::DeBoorNet ts::BSpline::operator()(const float u) const
 {
     return evaluate(u);
 }
 
+#ifdef WITH_MOVE_SEMANTICS
 void ts::BSpline::swap(ts::BSpline &other)
 {
     if (&other != this) {
@@ -188,6 +197,7 @@ void ts::BSpline::swap(ts::BSpline &other)
         std::swap(bspline.knots, other.bspline.knots);
     }
 }
+#endif
 
 size_t ts::BSpline::deg() const
 {
@@ -249,7 +259,7 @@ void ts::BSpline::setCtrlp(const std::vector<float> ctrlp)
             " spline's number of control points multiplied by the dimension"
             " of each control point.");
     }
-    const tsError err = ts_bspline_set_ctrlp(&bspline, ctrlp.data(), &bspline);
+    const tsError err = ts_bspline_set_ctrlp(&bspline, &ctrlp.front(), &bspline);
     if (err < 0)
         throw std::runtime_error(ts_enum_str(err));
 }

--- a/library/tinysplinecpp.cpp
+++ b/library/tinysplinecpp.cpp
@@ -270,7 +270,7 @@ void ts::BSpline::setKnots(const std::vector<float> knots)
         throw std::runtime_error("The number of values must be equals to the"
         " spline's number of knots.");
     }
-    const tsError err = ts_bspline_set_knots(&bspline, knots.data(), &bspline);
+    const tsError err = ts_bspline_set_knots(&bspline, &knots.front(), &bspline);
     if (err < 0)
         throw std::runtime_error(ts_enum_str(err));
 }

--- a/library/tinysplinecpp.h
+++ b/library/tinysplinecpp.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef TINYSPLINECPP_H
+#define	TINYSPLINECPP_H
 
 #include "tinyspline.h"
 #include <vector>
@@ -10,14 +11,18 @@ class DeBoorNet {
 public:
     DeBoorNet();
     DeBoorNet(const DeBoorNet& other);
+#ifdef USE_MOVE_SEMANTICS
     DeBoorNet(DeBoorNet&& other);
+#endif
     ~DeBoorNet();
 
     DeBoorNet& operator=(const DeBoorNet& other);
+#ifdef USE_MOVE_SEMANTICS
     DeBoorNet& operator=(DeBoorNet&& other);
 
     void swap(DeBoorNet& other);
     friend void swap(DeBoorNet &left, DeBoorNet &right) { left.swap(right); }
+#endif
 
     float u() const;
     size_t k() const;
@@ -38,7 +43,9 @@ public:
     /* Constructors */
     BSpline();
     BSpline(const BSpline& other);
+#ifdef USE_MOVE_SEMANTICS
     BSpline(BSpline&& other);
+#endif
     BSpline(const size_t deg, const size_t dim, const size_t nCtrlp,
             const tsBSplineType type);
     BSpline(const std::vector<float> points, const size_t dim);
@@ -46,12 +53,16 @@ public:
 
     /* Operators */
     BSpline& operator=(const BSpline& other);
+#ifdef USE_MOVE_SEMANTICS
     BSpline& operator=(BSpline&& other);
+#endif
     DeBoorNet operator()(const float u) const;
 
+#ifdef USE_MOVE_SEMANTICS
     /* Used by move semantics */
     void swap(BSpline& other);
     friend void swap(BSpline &left, BSpline &right) { left.swap(right); }
+#endif
 
     /* Getter */
     size_t deg() const;
@@ -84,11 +95,15 @@ private:
 
 class Utils {
 public:
-    Utils() = delete;
 
     static bool fequals(const float x, const float y);
     static std::string enum_str(const tsError err);
     static tsError str_enum(const std::string str);
+
+private:
+	Utils() {}
 };
 
 }
+
+#endif	/* TINYSPLINECPP_H */


### PR DESCRIPTION
made move semantics optional for not C+11 compilers, added options to build example/bindings, added solution folder to group examples and bindings in IDE

![devenv_2016-06-14_10-55-07](https://cloud.githubusercontent.com/assets/2849257/16047551/7a20722e-321e-11e6-9fd4-1d613a99cc2d.png)
