### PR TITLE
fix assumes freeglutd.lib in the same folder as freeglut.lib 

### DIFF
--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -2,6 +2,10 @@
 find_package(GLUT)
 if(GLUT_FOUND)
   include_directories(${GLUT_INCLUDE_DIR})
+  if(MSVC)
+    # to fix a debug issue: http://stackoverflow.com/q/29110985/2741329
+    get_filename_component( GLUT_LIBRARY_DIRS ${GLUT_glut_LIBRARY} DIRECTORY)  
+  endif()  
   link_directories(${GLUT_LIBRARY_DIRS})
   add_definitions(${GLUT_DEFINITIONS})
 endif()


### PR DESCRIPTION
The freeglut's CMake installs both libraries in the same folder.

This should solve: https://github.com/retuxx/tinyspline/issues/63